### PR TITLE
Provide line number and file name for debugging embedded c#

### DIFF
--- a/lib/edge.js
+++ b/lib/edge.js
@@ -44,7 +44,13 @@ exports.func = function(language, options) {
         }
     }
     else if (typeof options === 'function') {
-        options = { source: options };
+        var originalPrepareStackTrace = Error.prepareStackTrace;
+        Error.prepareStackTrace = function(error, stack) {
+            return stack;
+        };
+        var stack = new Error().stack;
+        Error.prepareStackTrace = originalPrepareStackTrace;
+        options = { source: options, jsFileName: stack[1].getFileName(), jsLineNumber: stack[1].getLineNumber() };
     }
     else if (typeof options !== 'object') {
         throw new Error('Specify the source code as string or provide an options object.');


### PR DESCRIPTION
When using the function syntax for providing C# code, this uses the v8 callstack api to provide the line number of the c# and the name of the javascript file to the language compiler to aid debugging.

Caveats:
1. This only works if the function providing the C# code is included inline as a parameter to the func function.
2. This is relatively fragile to any refactoring of edge.js that changes the callstack between the user's script and the code using the callstack.

ref: #6
