### PR TITLE
 Remove reference to CLRFuncContext in NodejsFunc and NodejsFuncContext

### DIFF
--- a/src/clrfuncinvokecontext.cpp
+++ b/src/clrfuncinvokecontext.cpp
@@ -55,7 +55,6 @@ void ClrFuncInvokeContext::CompleteOnCLRThread(System::Threading::Tasks::Task<Sy
 
 void ClrFuncInvokeContext::CompleteOnV8ThreadAsynchronous()
 {
-    HandleScope scope;
     this->CompleteOnV8Thread(false);
 }
 

--- a/src/edge.h
+++ b/src/edge.h
@@ -106,7 +106,7 @@ public:
 
     property Persistent<Function>* Func;
 
-    NodejsFunc(ClrFuncInvokeContext^ appInvokeContext, Handle<Function> function);
+    NodejsFunc(Handle<Function> function);
     ~NodejsFunc();
     !NodejsFunc();
 
@@ -177,7 +177,7 @@ public:
     static Handle<v8::Function> Initialize(System::Func<System::Object^,Task<System::Object^>^>^ func);
     Handle<v8::Value> Call(Handle<v8::Value> payload, Handle<v8::Value> callback);
     static Handle<v8::Value> MarshalCLRToV8(System::Object^ netdata);
-    static System::Object^ MarshalV8ToCLR(ClrFuncInvokeContext^ context, Handle<v8::Value> jsdata);    
+    static System::Object^ MarshalV8ToCLR(Handle<v8::Value> jsdata);    
 };
 
 typedef struct clrFuncWrap {

--- a/src/nodejsfunc.cpp
+++ b/src/nodejsfunc.cpp
@@ -16,6 +16,13 @@
  */
 #include "edge.h"
 
+NodejsFunc::NodejsFunc(Handle<Function> function)
+{
+    DBG("NodejsFunc::NodejsFunc");
+    this->Func = new Persistent<Function>;
+    *(this->Func) = Persistent<Function>::New(function);
+}
+
 NodejsFunc::~NodejsFunc()
 {
     this->!NodejsFunc();
@@ -28,13 +35,6 @@ NodejsFunc::!NodejsFunc()
     uv_edge_async_t* uv_edge_async = V8SynchronizationContext::RegisterAction(
         gcnew System::Action(context, &PersistentDisposeContext::CallDisposeOnV8Thread));
     V8SynchronizationContext::ExecuteAction(uv_edge_async);
-}
-
-NodejsFunc::NodejsFunc(ClrFuncInvokeContext^ appInvokeContext, Handle<Function> function)
-{
-    DBG("NodejsFunc::NodejsFunc");
-    this->Func = new Persistent<Function>;
-    *(this->Func) = Persistent<Function>::New(function);
 }
 
 Task<System::Object^>^ NodejsFunc::FunctionWrapper(System::Object^ payload)

--- a/src/nodejsfuncinvokecontext.cpp
+++ b/src/nodejsfuncinvokecontext.cpp
@@ -118,7 +118,7 @@ void NodejsFuncInvokeContext::CompleteWithResult(Handle<v8::Value> result)
     DBG("NodejsFuncInvokeContext::CompleteWithResult");
     try 
     {
-        this->result = ClrFunc::MarshalV8ToCLR(nullptr, result);
+        this->result = ClrFunc::MarshalV8ToCLR(result);
         Task::Run(gcnew System::Action(this, &NodejsFuncInvokeContext::Complete));
     }
     catch (System::Exception^ e)

--- a/test/tests.cs
+++ b/test/tests.cs
@@ -176,6 +176,7 @@ namespace Edge.Tests
 
             // Now simulate an event callback after this CLR method has finished.
             Task.Delay(50).ContinueWith(async (value) => {
+                GC.Collect();
                 // This throws an exception if the weak reference is not
                 // pointing to an existing object.
                 GC.GetGeneration(weakRefToNodejsFunc);


### PR DESCRIPTION
Since we are now garbage collecting NodejsFunc object it is not necessary anymore that NodejsFunc and NodejsFuncContext reference CLRFuncContext
