### PR TITLE
dynamic support?

### DIFF
--- a/src/clrfunc.cpp
+++ b/src/clrfunc.cpp
@@ -1,5 +1,7 @@
 #include "edge.h"
 
+#using <System.Core.dll>
+
 ClrFunc::ClrFunc()
 {
     // empty
@@ -304,7 +306,7 @@ System::Object^ ClrFunc::MarshalV8ToCLR(Handle<v8::Value> jsdata)
     }
     else if (jsdata->IsObject()) 
     {
-        Dictionary<System::String^,System::Object^>^ netobject = gcnew Dictionary<System::String^,System::Object^>();
+        IDictionary<System::String^,System::Object^>^ netobject = gcnew System::Dynamic::ExpandoObject();
         Handle<v8::Object> jsobject = Handle<v8::Object>::Cast(jsdata);
         Handle<v8::Array> propertyNames = jsobject->GetPropertyNames();
         for (unsigned int i = 0; i < propertyNames->Length(); i++)


### PR DESCRIPTION
What if one could do this?

``` csharp
public async Task<object> Invoke(dynamic input)
{
    int anInteger = input.anInteger;
    double aNumber = input.aNumber;
    string aString = input.aString;
    bool aBoolean = input.aBoolean;
    byte[] aBuffer = input.aBuffer;
    object[] anArray = input.anArray;
    dynamic anObject = input.anObject;

    return null;
}
```

Or this:

``` csharp
public async Task<object> Invoke(dynamic input)
{
    var twoNumbers = new { a = 2, b = 3 };
    int addResult = await input.add(twoNumbers);
    return addResult * 2;
}
```

I have no idea if `dynamic` and `await` will even play nicely together, particularly in the second example, but this seems like an ideal place to let the DLR go to town.

Is anyone working on this? Has it been tried?
