### PR TITLE
Fix marshalling of empty byte[]/Buffer

### DIFF
--- a/src/clrfunc.cpp
+++ b/src/clrfunc.cpp
@@ -194,6 +194,16 @@ Handle<v8::Value> ClrFunc::MarshalCLRToV8(System::Object^ netdata)
         };
         jsdata = bufferConstructor->NewInstance(3, args);    
     }
+    else if (dynamic_cast<System::Collections::Generic::IDictionary<System::String^,System::Object^>^>(netdata) != nullptr)
+    {
+        Handle<v8::Object> result = v8::Object::New();
+        for each (System::Collections::Generic::KeyValuePair<System::String^,System::Object^>^ pair in (System::Collections::Generic::IDictionary<System::String^,System::Object^>^)netdata)
+        {
+            result->Set(stringCLR2V8(pair->Key), ClrFunc::MarshalCLRToV8(pair->Value));
+        }
+
+        jsdata = result;
+    }
     else if (dynamic_cast<System::Collections::IDictionary^>(netdata) != nullptr)
     {
         Handle<v8::Object> result = v8::Object::New();

--- a/test/tests.cs
+++ b/test/tests.cs
@@ -15,6 +15,7 @@
  * permissions and limitations under the License.
  */
 using System;
+using System.Dynamic;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
@@ -109,17 +110,16 @@ namespace Edge.Tests
 
         public Task<object> MarshalBack(dynamic input)
         {
-            var result = new {
-                a = 1,
-                b = 3.1415,
-                c = "foo",
-                d = true,
-                e = false,
-                f = new byte[10],
-                g = new object[] { 1, "foo" },
-                h = new { a = "foo", b = 12 },
-                i = (Func<object,Task<object>>)(async (i) => { return i; })
-            };
+            dynamic result = new ExpandoObject();
+            result.a = 1;
+            result.b = 3.1415;
+            result.c = "foo";
+            result.d = true;
+            result.e = false;
+            result.f = new byte[10];
+            result.g = new object[] { 1, "foo" };
+            result.h = new { a = "foo", b = 12 };
+            result.i = (Func<object, Task<object>>)(async (i) => { return i; });
 
             return Task.FromResult<object>(result);
         }       
@@ -149,17 +149,17 @@ namespace Edge.Tests
 
         public async Task<object> MarshalInFromNet(dynamic input)
         {
-            var payload = new {
-                a = 1,
-                b = 3.1415,
-                c = "foo",
-                d = true,
-                e = false,
-                f = new byte[10],
-                g = new object[] { 1, "foo" },
-                h = new { a = "foo", b = 12 },
-                i = (Func<object,Task<object>>)(async (i) => { return i; })
-            };          
+            dynamic payload = new ExpandoObject();
+            payload.a = 1;
+            payload.b = 3.1415;
+            payload.c = "foo";
+            payload.d = true;
+            payload.e = false;
+            payload.f = new byte[10];
+            payload.g = new object[] { 1, "foo" };
+            payload.h = new { a = "foo", b = 12 };
+            payload.i = (Func<object, Task<object>>)(async (i) => { return i; });
+
             var result = await input.hello(payload);
             return result;
         }


### PR DESCRIPTION
Empty arrays can't be pinned:

``` cpp
cli::array<byte>^ buffer = (cli::array<byte>^)netdata;
pin_ptr<unsigned char> pinnedBuffer = &buffer[0]; // throw IndexOutOfRangeException
```

``` cpp
cli::array<byte>^ netbuffer = gcnew cli::array<byte>((int)node::Buffer::Length(jsbuffer));
pin_ptr<byte> pinnedNetbuffer = &netbuffer[0]; // throw IndexOutOfRangeException
```
