### PR TITLE
Mono build messages

### DIFF
--- a/tools/install.js
+++ b/tools/install.js
@@ -51,10 +51,7 @@ if(process.platform === 'win32') {
 	var gypPath = path.resolve(__dirname, '../node_modules/node-gyp/bin/node-gyp.js')
 
 	require('child_process')
-		.spawn('node-gyp', ['rebuild'])
-		.on('error', function(err) {
-			console.log(err)
-		})
+		.spawn('node-gyp', ['rebuild'], { stdio: 'inherit' })
 }
 
 


### PR DESCRIPTION
Fixes an issue with the way child_process.spawn is called for the mono build so that build messages are now visible.

https://github.com/tjanczuk/edge/issues/3
