### PR TITLE
Test assembly now compiles before tests are run

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "scripts": {
   	"install": "node tools/install.js",
-    "test": "node test/test.js",
+    "test": "node tools/test.js",
     "jshint": "node ./tools/runJsHint.js"
   }
 }

--- a/tools/test.js
+++ b/tools/test.js
@@ -1,7 +1,8 @@
 var spawn = require('child_process').spawn
 	, path = require('path')
-	, input = path.resolve(__dirname, 'tests.cs')
-	, output = path.resolve(__dirname, 'Edge.Tests.dll')
+	, testDir = path.resolve(__dirname, '../test')
+	, input = path.resolve(testDir, 'tests.cs')
+	, output = path.resolve(testDir, 'Edge.Tests.dll')
 	, buildParameters = ['-target:library', '/debug', '-out:' + output, input]
 	, winBuild = []
 	, monoBuild = ['-sdk:4.5']
@@ -9,16 +10,16 @@ var spawn = require('child_process').spawn
 	;
 
 if(process.platform === 'win32') {
-	spawn('csc', winBuild.concat(buildParameters))
+	spawn('csc', winBuild.concat(buildParameters), { stdio: 'inherit' })
 		.on('close', runOnSuccess);
 } else {
-	spawn('dmcs', monoBuild.concat(buildParameters))
+	spawn('dmcs', monoBuild.concat(buildParameters), { stdio: 'inherit' })
 		.on('close', runOnSuccess);
 }
 
 function runOnSuccess(code, signal) {
 	if(code === 0) {
-		spawn('node', [mocha, '-R', 'spec'], { stdio: 'inherit' })
+		spawn('node', [mocha, testDir, '-R', 'spec'], { stdio: 'inherit' })
 			.on('error', function(err) { console.log(err); });
 	}
 }


### PR DESCRIPTION
Since mocha is a dev dependency, I just run it out of the node_modules folder. I can add a check for a globally installed mocha if need be.

https://github.com/tjanczuk/edge/issues/3
