### PR TITLE
Allow trailing ws after source as JS comment

### DIFF
--- a/lib/edge.js
+++ b/lib/edge.js
@@ -106,7 +106,7 @@ exports.func = function(language, options) {
     }
 
     if (typeof options.source === 'function') {
-        var match = options.source.toString().match(/[^]*\/\*([^]*)\*\/\}$/);
+        var match = options.source.toString().match(/[^]*\/\*([^]*)\*\/\s*\}$/);
         if (match) {
             options.source = match[1];
         }


### PR DESCRIPTION
When an Edge function is created from source in a JS comment and there's trailing white space between the end of the comment and the closing brace of the function, like:

```
var getTop10Products = edge.func('sql', function () {
    /*
    select top 10 * from Products
    */
});
```

then you get the following run-time error message:

> If .NET source is provided as JavaScript function, function body must be a /\* ... */ comment.

This change proposes to allow trailing space. Not only is it friendlier to formatting style differences but also _transcompilers_ like TypeScript. For example, the following in TypeScript: 

```
var getTop10Products = edge.func('sql', () => {/*
    SELECT TOP 10 * FROM Series
*/});
```

doesn't work as it produces the following JavaScript:

```
var getTop10Products = edge.func('sql', function () {
});
```

To get the comment to appear in the output JavaScript, the `/*` need to go on the next line:

```
var getTop10Products = edge.func('sql', () => {
    /*
    SELECT TOP 10 * FROM Series
*/});
```

but now this yields white space around the comment in the output:

```
var getTop10Products = edge.func('sql', function () {
    /*
    SELECT TOP 10 * FROM Series
    */
});
```

Relaxing the regular expression used to extract the foreign source to allow trailing white space avoids unnecessary surprises, especially with transcompilers where the output formatting of the JavaScript may not be in control of the developer.
