### PR TITLE
Fix syntax for inline add7 example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ var add7 = edge.func(function() {/*
         public async Task<object> Invoke(object input)
         {
             int v = (int)input;
-            return Helper::AddSeven(v);
+            return Helper.AddSeven(v);
         }
     }
 


### PR DESCRIPTION
Replace cpp syntax (Helper::AddSeven) with C# (Helper.AddSeven)
