### PR TITLE
Node 0.11.13

### DIFF
--- a/lib/edge.js
+++ b/lib/edge.js
@@ -5,7 +5,8 @@ var fs = require('fs')
 
 var versionMap = [
     [ /^0\.8\./, '0.8.22' ],
-    [ /^0\.10\./, '0.10.0' ]
+    [ /^0\.10\./, '0.10.0' ],
+    [ /^0\.11\./, '0.11.13' ]
 ];
 
 function determineVersion() {

--- a/src/common/edge_common.h
+++ b/src/common/edge_common.h
@@ -59,10 +59,10 @@ typedef int BOOL;
 // http://sambro.is-super-awesome.com/2011/03/03/creating-a-proper-buffer-in-a-node-c-addon/
 extern BOOL debugMode;
 extern BOOL enableScriptIgnoreAttribute;
-extern Persistent<Function> bufferConstructor;
+extern Persistent<Function, CopyablePersistentTraits<Function>> bufferConstructor;
 
 #ifdef EDGE_PLATFORM_WINDOWS
-#define DBG(msg) if (debugMode) System::Console::WriteLine(msg);
+#define DBG(msg) if (debugMode) ::OutputDebugString(msg); // System::Console::WriteLine(msg);
 #else
 #define DBG(msg) if (debugMode) printf(msg "\n");
 #endif

--- a/src/common/v8synchronizationcontext.cpp
+++ b/src/common/v8synchronizationcontext.cpp
@@ -16,12 +16,13 @@
  */
 #include "edge_common.h"
 
-void continueOnV8Thread(uv_async_t* handle, int status)
+void continueOnV8Thread(uv_async_t* handle)
 {
     // This executes on V8 thread
 
     DBG("continueOnV8Thread");
-    HandleScope handleScope;
+	Isolate* isolate = Isolate::GetCurrent();
+    HandleScope handleScope(isolate);
     uv_edge_async_t* uv_edge_async = (uv_edge_async_t*)handle;
     uv_async_edge_cb action = uv_edge_async->action;
     void* data = uv_edge_async->data;

--- a/src/dotnet/clrfuncinvokecontext.cpp
+++ b/src/dotnet/clrfuncinvokecontext.cpp
@@ -19,10 +19,13 @@
 ClrFuncInvokeContext::ClrFuncInvokeContext(Handle<v8::Value> callbackOrSync)
 {
     DBG("ClrFuncInvokeContext::ClrFuncInvokeContext");
-    if (callbackOrSync->IsFunction())
+
+	Isolate* isolate = Isolate::GetCurrent();
+	
+	if (callbackOrSync->IsFunction())
     {
-        this->callback = new Persistent<Function>;
-        *(this->callback) = Persistent<Function>::New(Handle<Function>::Cast(callbackOrSync));
+		this->callback = new Persistent<Function, CopyablePersistentTraits<Function>>();
+		*(this->callback) = Persistent<Function, CopyablePersistentTraits<Function>>(isolate, Handle<Function>::Cast(callbackOrSync));
         this->Sync = false;
     }
     else 
@@ -38,8 +41,7 @@ void ClrFuncInvokeContext::DisposeCallback()
     if (this->callback)
     {
         DBG("ClrFuncInvokeContext::DisposeCallback");
-        (*(this->callback)).Dispose();
-        (*(this->callback)).Clear();
+		(*(this->callback)).Reset();
         delete this->callback;
         this->callback = NULL;        
     }
@@ -65,7 +67,8 @@ void ClrFuncInvokeContext::InitializeAsyncOperation()
 
 void ClrFuncInvokeContext::CompleteOnV8ThreadAsynchronous()
 {
-    HandleScope scope;
+	Isolate* isolate = Isolate::GetCurrent();
+    HandleScope scope(isolate);
     this->CompleteOnV8Thread();
 }
 
@@ -73,7 +76,8 @@ Handle<v8::Value> ClrFuncInvokeContext::CompleteOnV8Thread()
 {
     DBG("ClrFuncInvokeContext::CompleteOnV8Thread");
 
-    HandleScope handleScope;
+	Isolate* isolate = Isolate::GetCurrent();
+	EscapableHandleScope handleScope(isolate);
 
     // The uv_edge_async was already cleaned up in V8SynchronizationContext::ExecuteAction
     this->uv_edge_async = NULL;
@@ -81,27 +85,29 @@ Handle<v8::Value> ClrFuncInvokeContext::CompleteOnV8Thread()
     if (!this->Sync && !this->callback)
     {
         // this was an async call without callback specified
-        DBG("ClrFuncInvokeContext::CompleteOnV8Thread - async without callback");
-        return handleScope.Close(Undefined());
+        return handleScope.Escape(Local<Value>::New(isolate, Undefined(isolate)));
     }
 
-    Handle<Value> argv[] = { Undefined(), Undefined() };
+	Local<Value> argv[] = { 
+		Local<Value>::New(isolate, Undefined(isolate)), 
+		Local<Value>::New(isolate, Undefined(isolate))
+	};
     int argc = 1;
 
     switch (this->Task->Status) {
         default:
-            argv[0] = v8::String::New("The operation reported completion in an unexpected state.");
+			argv[0] = v8::String::NewFromUtf8( isolate, "The operation reported completion in an unexpected state.");
         break;
         case TaskStatus::Faulted:
             if (this->Task->Exception != nullptr) {
-                argv[0] = ClrFunc::MarshalCLRExceptionToV8(this->Task->Exception);
+                argv[0] = exceptionCLR2stringV8(this->Task->Exception);
             }
             else {
-                argv[0] = v8::String::New("The operation has failed with an undetermined error.");
+                argv[0] = v8::String::NewFromUtf8( isolate, "The operation has failed with an undetermined error.");
             }
         break;
         case TaskStatus::Canceled:
-            argv[0] = v8::String::New("The operation was cancelled.");
+            argv[0] = v8::String::NewFromUtf8( isolate, "The operation was cancelled.");
         break;
         case TaskStatus::RanToCompletion:
             argc = 2;
@@ -110,7 +116,7 @@ Handle<v8::Value> ClrFuncInvokeContext::CompleteOnV8Thread()
             }
             catch (System::Exception^ e) {
                 argc = 1;
-                argv[0] = ClrFunc::MarshalCLRExceptionToV8(e);
+                argv[0] = exceptionCLR2stringV8(e);
             }
         break;
     };
@@ -119,26 +125,24 @@ Handle<v8::Value> ClrFuncInvokeContext::CompleteOnV8Thread()
     {
         // complete the asynchronous call to C# by invoking a callback in JavaScript
         TryCatch try_catch;
-        (*(this->callback))->Call(v8::Context::GetCurrent()->Global(), argc, argv);
+		Local<Function> localFunctionCall = Local<Function>::New(isolate, *(this->callback));
+		localFunctionCall->Call(isolate->GetCurrentContext()->Global(), argc, argv);
         this->DisposeCallback();
         if (try_catch.HasCaught()) 
         {
             node::FatalException(try_catch);
         }        
 
-        DBG("ClrFuncInvokeContext::CompleteOnV8Thread - async with callback");
-        return handleScope.Close(Undefined());
+        return handleScope.Escape(Local<Value>::New( isolate, Undefined(isolate)));
     }
     else if (1 == argc) 
     {
-        DBG("ClrFuncInvokeContext::CompleteOnV8Thread - handleScope.Close(ThrowException(argv[0]))");
         // complete the synchronous call to C# by re-throwing the resulting exception
-        return handleScope.Close(ThrowException(argv[0]));
+        return handleScope.Escape(isolate->ThrowException(argv[0]));
     }
     else
     {
-        DBG("ClrFuncInvokeContext::CompleteOnV8Thread - handleScope.Close(argv[1])");
         // complete the synchronous call to C# by returning the result
-        return handleScope.Close(argv[1]);
+        return handleScope.Escape(argv[1]);
     }
 }

--- a/src/dotnet/edge.cpp
+++ b/src/dotnet/edge.cpp
@@ -1,23 +1,31 @@
-#include "edge.h"
+#pragma unmanaged
+
+#include "../common/edge_common.h"
 
 BOOL debugMode;
 BOOL enableScriptIgnoreAttribute;
-Persistent<Function> bufferConstructor;
 
-Handle<Value> initializeClrFunc(const v8::Arguments& args)
+v8::Persistent<v8::Function,v8::CopyablePersistentTraits<v8::Function>> bufferConstructor;
+
+// Handle<Value> 
+void initializeClrFunc(const v8::FunctionCallbackInfo<Value>& args);
+
+void exitCallback( void * arg )
 {
-    return ClrFunc::Initialize(args);
+	bufferConstructor.Reset();
 }
 
-void init(Handle<Object> target) 
+void init(v8::Handle<v8::Object> target) 
 {
-    DBG("edge::init");
-    V8SynchronizationContext::Initialize();
-    bufferConstructor = Persistent<Function>::New(Handle<Function>::Cast(
-        Context::GetCurrent()->Global()->Get(String::New("Buffer")))); 
+	DBG("edge::init");
+	V8SynchronizationContext::Initialize();
+	Isolate * isolate = Isolate::GetCurrent();
+	bufferConstructor = Persistent<Function, CopyablePersistentTraits<Function>>(isolate, Handle<Function>::Cast(
+		isolate->GetCurrentContext()->Global()->Get(String::NewFromUtf8(isolate, "Buffer"))));
     debugMode = (0 < GetEnvironmentVariable("EDGE_DEBUG", NULL, 0));
     enableScriptIgnoreAttribute = (0 < GetEnvironmentVariable("EDGE_ENABLE_SCRIPTIGNOREATTRIBUTE", NULL, 0));
     NODE_SET_METHOD(target, "initializeClrFunc", initializeClrFunc);
+	node::AtExit(exitCallback, 0);
 }
 
-NODE_MODULE(edge, init);
+NODE_MODULE(edge, init)

--- a/src/dotnet/edge.h
+++ b/src/dotnet/edge.h
@@ -31,10 +31,11 @@ using namespace System::Threading::Tasks;
 using namespace System::Threading;
 using namespace System::Web::Script::Serialization;
 
-Handle<v8::String> stringCLR2V8(System::String^ text);
+Local<v8::String> stringCLR2V8(System::String^ text);
 System::String^ stringV82CLR(Handle<v8::String> text);
 System::String^ exceptionV82stringCLR(Handle<v8::Value> exception);
-Handle<Value> throwV8Exception(Handle<Value> exception);
+Local<v8::String> exceptionCLR2stringV8(System::Exception^ exception);
+Local<v8::Value> throwV8Exception(System::Exception^ exception);
 
 typedef struct clrActionContext {
     gcroot<System::Action^> action;
@@ -43,7 +44,7 @@ typedef struct clrActionContext {
 
 ref class ClrFuncInvokeContext {
 private:
-    Persistent<Function>* callback;
+    Persistent<Function,CopyablePersistentTraits<Function>>* callback;
     uv_edge_async_t* uv_edge_async;
 
     void DisposeCallback();
@@ -65,7 +66,7 @@ public:
 ref class NodejsFunc {
 public:
 
-    property Persistent<Function>* Func;
+	property Persistent<Function, CopyablePersistentTraits<Function>>* Func;
 
     NodejsFunc(Handle<Function> function);
     ~NodejsFunc();
@@ -131,14 +132,13 @@ private:
 
     ClrFunc();
 
-    static Handle<v8::Object> MarshalCLRObjectToV8(System::Object^ netdata);
+    static Handle<v8::Value> MarshalCLRObjectToV8(System::Object^ netdata);
 
 public:
-    static Handle<v8::Value> Initialize(const v8::Arguments& args);
+	static void Initialize(const v8::FunctionCallbackInfo<Value>& args);
     static Handle<v8::Function> Initialize(System::Func<System::Object^,Task<System::Object^>^>^ func);
     Handle<v8::Value> Call(Handle<v8::Value> payload, Handle<v8::Value> callback);
     static Handle<v8::Value> MarshalCLRToV8(System::Object^ netdata);
-    static Handle<v8::Value> MarshalCLRExceptionToV8(System::Exception^ exception);
     static System::Object^ MarshalV8ToCLR(Handle<v8::Value> jsdata);    
 };
 

--- a/src/dotnet/edge.h
+++ b/src/dotnet/edge.h
@@ -34,8 +34,7 @@ using namespace System::Web::Script::Serialization;
 Local<v8::String> stringCLR2V8(System::String^ text);
 System::String^ stringV82CLR(Handle<v8::String> text);
 System::String^ exceptionV82stringCLR(Handle<v8::Value> exception);
-Local<v8::String> exceptionCLR2stringV8(System::Exception^ exception);
-Local<v8::Value> throwV8Exception(System::Exception^ exception);
+Local<v8::Value> throwV8Exception(Handle<Value> exception);
 
 typedef struct clrActionContext {
     gcroot<System::Action^> action;
@@ -132,13 +131,14 @@ private:
 
     ClrFunc();
 
-    static Handle<v8::Value> MarshalCLRObjectToV8(System::Object^ netdata);
+	static Local<v8::Object> MarshalCLRObjectToV8(System::Object^ netdata);
 
 public:
 	static void Initialize(const v8::FunctionCallbackInfo<Value>& args);
     static Handle<v8::Function> Initialize(System::Func<System::Object^,Task<System::Object^>^>^ func);
     Handle<v8::Value> Call(Handle<v8::Value> payload, Handle<v8::Value> callback);
-    static Handle<v8::Value> MarshalCLRToV8(System::Object^ netdata);
+    static Local<v8::Value> MarshalCLRToV8(System::Object^ netdata);
+    static Local<v8::Value> MarshalCLRExceptionToV8(System::Exception^ exception);	
     static System::Object^ MarshalV8ToCLR(Handle<v8::Value> jsdata);    
 };
 

--- a/src/dotnet/nodejsfunc.cpp
+++ b/src/dotnet/nodejsfunc.cpp
@@ -19,8 +19,8 @@
 NodejsFunc::NodejsFunc(Handle<Function> function)
 {
     DBG("NodejsFunc::NodejsFunc");
-    this->Func = new Persistent<Function>;
-    *(this->Func) = Persistent<Function>::New(function);
+	this->Func = new Persistent<Function, CopyablePersistentTraits<Function>>();
+	*(this->Func) = Persistent<Function, CopyablePersistentTraits<Function>>(Isolate::GetCurrent(), function);
 }
 
 NodejsFunc::~NodejsFunc()

--- a/src/dotnet/persistentdisposecontext.cpp
+++ b/src/dotnet/persistentdisposecontext.cpp
@@ -26,7 +26,6 @@ void PersistentDisposeContext::CallDisposeOnV8Thread() {
     DBG("PersistentDisposeContext::CallDisposeOnV8Thread");
 
     Persistent<Value>* handle = (Persistent<Value>*)ptr.ToPointer();
-    (*handle).Dispose();
-    (*handle).Clear();
+    (*handle).Reset();
     delete handle;
 }

--- a/src/dotnet/utils.cpp
+++ b/src/dotnet/utils.cpp
@@ -49,23 +49,9 @@ System::String^ exceptionV82stringCLR(Handle<v8::Value> exception)
     return gcnew System::String(stringV82CLR(Handle<v8::String>::Cast(exception)));
 }
 
-Local<String> exceptionCLR2stringV8(System::Exception^ exception)
+Local<Value> throwV8Exception(Handle<Value> exception)
 {
 	Isolate* isolate = Isolate::GetCurrent();
 	EscapableHandleScope scope(isolate);
-	if (exception == nullptr)
-    {
-		return scope.Escape(v8::String::NewFromUtf8(isolate, "Unrecognized exception thrown by CLR."));
-    }
-    else
-    {
-        return scope.Escape(stringCLR2V8(exception->ToString()));
-    }
-}
-
-Local<Value> throwV8Exception(System::Exception^ exception)
-{
-	Isolate* isolate = Isolate::GetCurrent();
-	EscapableHandleScope scope(isolate);
-	return scope.Escape(isolate->ThrowException(exceptionCLR2stringV8(exception)));
+    return scope.Escape(isolate->ThrowException(exception));
 }


### PR DESCRIPTION
This is a first hack at getting Edge to run with the latest (unstable) node.js - 0.11.13.   Mainly so I can play with the co library.  I've only had a couple of days to go over this - so I'm sure that some of my changes could be replaced with something more concise.  Don't have any info on performance issues, and since the changes in Persistent class means that a Local<Value> handle needs to be created for each call, it's possible the memory leak referenced in https://github.com/tjanczuk/edge/issues/125 is back.  

There have been quite a few changes in v8: 

* the addition of Isolate, 
* changes to String::New and String::NewSymbol.  
* The use of EscapeableHandleScope::Escape instead of HandleScope::Close
* Global object now obtained via the Isolate, 
* Exceptions thrown via the Isolate, 
* New generally requires an Isolate
* Persistent now does not inherit from Object; need for CopyablePersistentTraits
* Arguments replaced with FunctionCallbackInfo<Value>

I've only made changes only made to the dotnet and common src files;  added 0.11.13 version tags in edge.js.

Hope it helps -- if it's not a timely update branch, feel free to ignore :-)

Regards
Tim Findlow