### PR TITLE
Mention binary module caveat in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Listen to the [Edge.js podcast on Herdingcode](http://herdingcode.com/herding-co
 &nbsp;&nbsp;&nbsp;&nbsp;[How to: exceptions](#how-to-exceptions)  
 &nbsp;&nbsp;&nbsp;&nbsp;[How to: app.config](#how-to-app-config)  
 &nbsp;&nbsp;&nbsp;&nbsp;[How to: debugging](#how-to-debugging)  
-&nbsp;&nbsp;&nbsp;&nbsp;[Performance](#performance)  exter
+&nbsp;&nbsp;&nbsp;&nbsp;[Performance](#performance)
 &nbsp;&nbsp;&nbsp;&nbsp;[Building on Windows](#building-on-windows)  
 &nbsp;&nbsp;&nbsp;&nbsp;[Building on OSX](#building-on-osx)  
 &nbsp;&nbsp;&nbsp;&nbsp;[Building on Linux](#building-on-linux)  


### PR DESCRIPTION
Added text to readme to mention that binary Node.js modules are not supported in Edge unless rebuilt to link against Edge's NodeJS dll.
