### PR TITLE
Bugfix for short (int16) support (dotnet)

### DIFF
--- a/src/dotnet/clrfunc.cpp
+++ b/src/dotnet/clrfunc.cpp
@@ -181,7 +181,7 @@ Handle<v8::Value> ClrFunc::MarshalCLRToV8(System::Object^ netdata)
     }
     else if (type == System::Int16::typeid)
     {
-        jsdata = NanNew<v8::Integer>((int)netdata);
+        jsdata = NanNew<v8::Integer>((short)netdata);
     }
     else if (type == System::Int64::typeid)
     {


### PR DESCRIPTION
Fix casting error with Int16 values when marshaling from CLR to javascript as described in  #258   #285