### PR TITLE
Install script updates and compile fixes for Linux system without Mono

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -48,6 +48,9 @@
                     'src/CoreCLREmbedding/coreclrnodejsfuncinvokecontext.cpp',
                     'src/common/utils.cpp'
                   ]
+                },
+                {
+                  'type': 'none'
                 }
               ]
             ]
@@ -67,6 +70,9 @@
                     'src/CoreCLREmbedding/coreclrnodejsfuncinvokecontext.cpp',
                     'src/common/utils.cpp'
                   ]
+                },
+                {
+                  'type': 'none'
                 }
               ]
             ]
@@ -180,6 +186,9 @@
                       '<!@(pkg-config mono-2 --libs)'
                     ],
                   }
+                },
+                {
+                  'type': 'none'
                 }
               ]
             ]

--- a/binding.gyp
+++ b/binding.gyp
@@ -23,7 +23,7 @@
         "<!(node -e \"require('nan')\")"
       ],
       'cflags+': [
-        '-DHAVE_CORECLR'
+        '-DHAVE_CORECLR -std=c++11'
       ],
       'xcode_settings': {
         'OTHER_CFLAGS': [
@@ -135,7 +135,7 @@
         "<!(node -e \"require('nan')\")"
       ],
       'cflags+': [
-        '-DHAVE_NATIVECLR'
+        '-DHAVE_NATIVECLR -std=c++11'
       ],
       'xcode_settings': {
         'OTHER_CFLAGS': [

--- a/lib/edge.js
+++ b/lib/edge.js
@@ -1,6 +1,6 @@
 var fs = require('fs')
     , path = require('path')
-    , builtEdge = path.resolve(__dirname, '../build/Release/' + (process.env.EDGE_USE_CORECLR ? 'edge_coreclr.node' : 'edge_nativeclr.node'))
+    , builtEdge = path.resolve(__dirname, '../build/Release/' + (process.env.EDGE_USE_CORECLR || !fs.existsSync(path.resolve(__dirname, '../build/Release/edge_nativeclr.node')) ? 'edge_coreclr.node' : 'edge_nativeclr.node'))
     , edge;
 
 var versionMap = [

--- a/tools/debian_wheezy_clean_install.sh
+++ b/tools/debian_wheezy_clean_install.sh
@@ -12,7 +12,7 @@ then
     apt-get update
 fi
 
-apt-get -y install curl g++ pkg-config libgdiplus libunwind8 libssl-dev unzip make mono-complete git
+apt-get -y install curl g++ pkg-config libgdiplus libunwind8 libssl-dev unzip make mono-complete git gettext libssl-dev libcurl4-openssl-dev zlib1g libicu-dev uuid-dev
 
 # download and build Node.js
 

--- a/tools/ubuntu_12.04_clean_install.sh
+++ b/tools/ubuntu_12.04_clean_install.sh
@@ -12,7 +12,7 @@ then
     apt-get update
 fi
 
-apt-get -y install curl g++ pkg-config libgdiplus libunwind8 libssl-dev unzip make mono-complete git
+apt-get -y install curl g++ pkg-config libgdiplus libunwind8 libssl-dev make mono-complete gettext libssl-dev libcurl4-openssl-dev zlib1g libicu-dev uuid-dev unzip
 
 # download and build Node.js
 


### PR DESCRIPTION
This PR fixes two issues:

1. The Linux install scripts now include the additional apt-get packages recommended by <https://docs.asp.net/en/latest/getting-started/installing-on-linux.html>.
2. When building the module on Linux systems without Mono installed, we no longer generate `edge_nativeclr.node`.  When `edge_nativeclr.node` is not available, we also fall back to trying to use `edge_coreclr.node`.  This removes the requirement that the `EDGE_USE_CORECLR=1` environment variable be set even if no alternative runtime is available.