### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1413,7 +1413,7 @@ using EdgeJs;
 
 class Program
 {
-    public static async void Start()
+    public static async Task Start()
     {
         var func = Edge.Func(@"
             return function (data, callback) {
@@ -1426,7 +1426,7 @@ class Program
 
     static void Main(string[] args)
     {
-        Task.Run((Action)Start).Wait();
+        Task.Run(Start).Wait();
     }
 }
 ```


### PR DESCRIPTION
> `async+void` can crash the system and usually should be used only on the UI side event handlers. 
http://stackoverflow.com/questions/12144077/async-await-when-to-return-a-task-vs-void