### PR TITLE
fix conditions in binding.gyp for mac

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -58,7 +58,7 @@
           {
             'conditions': [
               [
-                '"<!(echo -n `which dnx`)"!=""',
+                '"<!((which dnx) || echo not_found)"!="not_found"',
                 {
                   'sources+': [
                     'src/common/v8synchronizationcontext.cpp',
@@ -162,7 +162,7 @@
           {
             'conditions': [
               [
-                '"<!(echo -n `which mono`)"!=""',
+                '"<!((which mono) || echo not_found)"!="not_found"',
                 {
                   'sources+': [
                     'src/mono/clractioncontext.cpp',
@@ -286,7 +286,7 @@
           {
             'conditions': [
               [
-                '"<!(echo -n `which mono`)"!=""',
+                '"<!((which mono) || echo not_found)"!="not_found"',
                 {
                   'actions+': [
                     {
@@ -310,7 +310,7 @@
                 }
               ],
               [
-                '"<!(echo -n `which dnx`)"!=""',
+                '"<!((which dnx) || echo not_found)"!="not_found"',
                 {
                   'actions+': [
                     {


### PR DESCRIPTION
Fix #386

The previous command expansions to test for dnx and mono being
installed did not actually work on mac osx previously. They have
been changed to a format that should be supported by most unix
shells:

`'"<!((which dnx) || echo not_found)"!="not_found"'`