### PR TITLE
make edge works with node-chakracore

### DIFF
--- a/README.md
+++ b/README.md
@@ -1201,6 +1201,20 @@ set EDGE_NATIVE=C:\projects\edge\build\Debug\edge_nativeclr.node
 
 You can also set the `EDGE_DEBUG` environment variable to 1 to have the edge module generate debug traces to the console when it runs.
 
+#### Building on Windows with [node-chakracore](https://github.com/nodejs/node-chakracore)
+
+**Note**: This support is experimental.
+
+To build with node-chakracore, install [latest node-chakracore release]
+(https://github.com/nodejs/node-chakracore/releases). You can only build edge
+for the installed node-chakracore version. Launch `Node.js (chakracore) command
+prompt` and run:
+
+```
+cd tools
+build.bat release
+```
+
 ### Running tests
 
 You must have mocha installed on the system. Then:

--- a/lib/edge.js
+++ b/lib/edge.js
@@ -11,10 +11,16 @@ var versionMap = [
     [ /^5\./, '5.1.0' ],
 ];
 
+function getNodeEngine() {
+    return process.jsEngine || 'v8';
+}
+
 function determineVersion() {
-    for (var i in versionMap) {
-        if (process.versions.node.match(versionMap[i][0])) {
-            return versionMap[i][1];
+    if (getNodeEngine() == 'v8') {
+        for (var i in versionMap) {
+            if (process.versions.node.match(versionMap[i][0])) {
+                return versionMap[i][1];
+            }
         }
     }
 
@@ -27,13 +33,18 @@ if (process.env.EDGE_NATIVE) {
     edgeNative = process.env.EDGE_NATIVE;
 }
 else if (process.platform === 'win32') {
-    edgeNative = './native/' + process.platform + '/' + process.arch + '/' + determineVersion() + '/' + (process.env.EDGE_USE_CORECLR ? 'edge_coreclr' : 'edge_nativeclr');
+    var nativeDir = './native/' + process.platform + '/' + process.arch;
+    var release = 'node-' + getNodeEngine() + '-' + process.versions.node;
+    var edgeFlavor = process.env.EDGE_USE_CORECLR ? 'edge_coreclr' : 'edge_nativeclr';
+    var version = fs.existsSync(path.resolve(__dirname, nativeDir, release, edgeFlavor + ".node")) ?
+                                release : determineVersion();
+    edgeNative = nativeDir + '/' + version + '/' + edgeFlavor;
 }
 else if (fs.existsSync(builtEdge)) {
     edgeNative = builtEdge;
 }
 else {
-    throw new Error('The edge native module is not available at ' + builtEdge 
+    throw new Error('The edge native module is not available at ' + builtEdge
         + '. You can use EDGE_NATIVE environment variable to provide alternate location of edge.node. '
         + 'If you need to build edge.node, follow build instructions for your platform at https://github.com/tjanczuk/edge');
 }
@@ -74,7 +85,7 @@ exports.func = function(language, options) {
         {
             Error.prepareStackTrace = originalPrepareStackTrace;
         }
-        
+
         options = { source: options, jsFileName: stack[1].getFileName(), jsLineNumber: stack[1].getLineNumber() };
     }
     else if (typeof options !== 'object') {

--- a/tools/build.bat
+++ b/tools/build.bat
@@ -3,6 +3,9 @@ set SELF=%~dp0
 if "%1" equ "" (
     echo Usage: build.bat debug^|release "{version} {version}" ...
     echo e.g. build.bat release "0.8.22 0.10.0"
+    echo      or
+    echo      build.bat release
+    echo                ^(builds for the current node.exe release^)
     exit /b -1
 )
 
@@ -24,31 +27,48 @@ if "%1" neq "" (
     shift
     goto :harvestVersions
 )
-if "%VERSIONS%" equ "" set VERSIONS=0.10.0
+if "%VERSIONS%" equ "" set VERSIONS=CURRENT_INSTALL
 pushd %SELF%\..
-for %%V in (%VERSIONS%) do call :build ia32 x86 %%V 
-for %%V in (%VERSIONS%) do call :build x64 x64 %%V 
+for %%V in (%VERSIONS%) do call :build ia32 x86 %%V
+for %%V in (%VERSIONS%) do call :build x64 x64 %%V
 popd
 
 exit /b 0
 
 :build
 
-set DESTDIR=%DESTDIRROOT%\%1\%3
-if exist "%DESTDIR%\node.exe" goto gyp
+set VERSION=%3
+set CURRENT_INSTALL=
+if "%VERSION%" == "CURRENT_INSTALL" (
+    set CURRENT_INSTALL=true
+    for /f "Tokens=*" %%i in ('node -pe "process.jsEngine || 'v8'"') do set NODEENGINE=%%i
+    for /f "Tokens=*" %%i in ('node -pe "process.versions.node"') do set VERSION=%%i
+)
+
+if "%CURRENT_INSTALL%" == "" (
+    set NODERELEASE=v%VERSION%
+    set NODEEXE=%DESTDIR%\node.exe
+    set GYP=%APPDATA%\npm\node_modules\node-gyp\bin\node-gyp.js
+) else (
+    set NODERELEASE=node-%NODEENGINE%-%VERSION%
+    REM NODEEXE remains the current node.exe path unchanged. GYP uses the current node.exe install
+    set GYP=%NODEDIR%\node_modules\npm\node_modules\node-gyp\bin\node-gyp.js
+)
+
+set DESTDIR=%DESTDIRROOT%\%1\%NODERELEASE%
 if not exist "%DESTDIR%\NUL" mkdir "%DESTDIR%"
-echo Downloading node.exe %2 %3...
-node "%SELF%\download.js" %2 %3 "%DESTDIR%"
+
+if exist "%NODEEXE%" goto gyp
+echo Downloading node.exe %2 %VERSION%...
+node "%SELF%\download.js" %2 %VERSION% "%DESTDIR%"
 if %ERRORLEVEL% neq 0 (
-    echo Cannot download node.exe %2 v%3
+    echo Cannot download node.exe %2 %NODERELEASE%
     exit /b -1
 )
 
 :gyp
 
-echo Building edge.node %FLAVOR% for node.js %2 v%3
-set NODEEXE=%DESTDIR%\node.exe
-set GYP=%APPDATA%\npm\node_modules\node-gyp\bin\node-gyp.js
+echo Building edge.node %FLAVOR% for node.js %2 %NODERELEASE%
 if not exist "%GYP%" (
     echo Cannot find node-gyp at %GYP%. Make sure to install with npm install node-gyp -g
     exit /b -1
@@ -58,21 +78,21 @@ if exist ".\src\CoreCLREmbedding\bin" rmdir /s /q ".\src\CoreCLREmbedding\bin"
 
 "%NODEEXE%" "%GYP%" configure build --msvs_version=2013 -%FLAVOR%
 if %ERRORLEVEL% neq 0 (
-    echo Error building edge.node %FLAVOR% for node.js %2 v%3
+    echo Error building edge.node %FLAVOR% for node.js %2 %NODERELEASE%
     exit /b -1
 )
 
 echo %DESTDIR%
 copy /y .\build\%FLAVOR%\edge_*.node "%DESTDIR%"
 if %ERRORLEVEL% neq 0 (
-    echo Error copying edge.node %FLAVOR% for node.js %2 v%3
+    echo Error copying edge.node %FLAVOR% for node.js %2 %NODERELEASE%
     exit /b -1
 )
 
 if exist ".\build\%FLAVOR%\CoreCLREmbedding.dll" (
     copy /y .\build\%FLAVOR%\CoreCLREmbedding.dll "%DESTDIR%"
     if %ERRORLEVEL% neq 0 (
-        echo Error copying CoreCLREmbedding.dll %FLAVOR% for node.js %2 v%3
+        echo Error copying CoreCLREmbedding.dll %FLAVOR% for node.js %2 %NODERELEASE%
         exit /b -1
     )
 )
@@ -83,4 +103,4 @@ if %ERRORLEVEL% neq 0 (
     exit /b -1
 )
 
-echo Success building edge.node %FLAVOR% for node.js %2 v%3
+echo Success building edge.node %FLAVOR% for node.js %2 %NODERELEASE%

--- a/tools/checkplatform.js
+++ b/tools/checkplatform.js
@@ -1,10 +1,18 @@
+var
+  path = require('path'),
+  spawn = require('child_process').spawn;
+
 try {
 	require('../lib/edge.js');
 }
 catch (e) {
-	console.log('***************************************');
-	console.log(e);
-	console.log('***************************************');
+  if (process.platform === 'win32' && /module has not been pre-compiled/.exec(e)) {
+    spawn(path.resolve(__dirname, 'build.bat'), ['release'], { stdio: 'inherit' });
+  } else {
+    console.log('***************************************');
+    console.log(e);
+    console.log('***************************************');
+  }
 }
 
 console.log('Success: platform check for edge.js: node.js ' + process.arch + ' v' + process.versions.node);

--- a/tools/whereis.js
+++ b/tools/whereis.js
@@ -17,5 +17,7 @@ module.exports = function() {
 	    }
     }
 
-    return null;
+    // Return empty string '' when not found. This supports "if (whereis_result) {...}"
+    // test, and also GYP condition test <(!node -e `...console.log(whereis_result)`) != ''
+    return '';
 }


### PR DESCRIPTION
This PR makes edge work with [node-chakracore](https://github.com/nodejs/node-chakracore).

All the changes are for build/install scripts. Assuming precompiled binaries are not available (would also work if they are available), these changes enable "npm install" to build from source for the current node/npm platform.
