### PR TITLE
Also check for a manual build on windows

### DIFF
--- a/lib/edge.js
+++ b/lib/edge.js
@@ -26,11 +26,11 @@ var edgeNative;
 if (process.env.EDGE_NATIVE) {
     edgeNative = process.env.EDGE_NATIVE;
 }
-else if (process.platform === 'win32') {
-    edgeNative = './native/' + process.platform + '/' + process.arch + '/' + determineVersion() + '/' + (process.env.EDGE_USE_CORECLR ? 'edge_coreclr' : 'edge_nativeclr');
-}
 else if (fs.existsSync(builtEdge)) {
     edgeNative = builtEdge;
+}
+else if (process.platform === 'win32') {
+    edgeNative = './native/' + process.platform + '/' + process.arch + '/' + determineVersion() + '/' + (process.env.EDGE_USE_CORECLR ? 'edge_coreclr' : 'edge_nativeclr');
 }
 else {
     throw new Error('The edge native module is not available at ' + builtEdge 


### PR DESCRIPTION
Moving the check for a manual build to before the win32 check allows manual builds to work out of the box with windows as well.