### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1522,8 +1522,9 @@ var createHttpServer = Edge.Func(@"
     };
 ");
 
-await createHttpServer(8080);
+var server = createHttpServer(8080);
 Console.WriteLine(await new WebClient().DownloadStringTaskAsync("http://localhost:8080"));
+await server;
 ```
 
 ### How to: use external Node.js modules


### PR DESCRIPTION
Sample code was hanging on `await createServer(8080);`, preventing the `WebClient` call to the server.
