### PR TITLE
Remove Microsoft.DotNet.ProjectModel dependency

### DIFF
--- a/src/double/Edge.js/dotnetcore/coreclrembedding.cs
+++ b/src/double/Edge.js/dotnetcore/coreclrembedding.cs
@@ -11,11 +11,7 @@ using System.Collections;
 using System.Threading.Tasks;
 using System.IO;
 using System.Diagnostics;
-using Microsoft.DotNet.ProjectModel;
-using Microsoft.DotNet.ProjectModel.Compilation;
-using Microsoft.DotNet.ProjectModel.Graph;
 using Microsoft.Extensions.DependencyModel;
-using NuGet.Frameworks;
 using DotNetRuntimeEnvironment = Microsoft.DotNet.InternalAbstractions.RuntimeEnvironment;
 using Semver;
 
@@ -145,7 +141,6 @@ public class CoreCLREmbedding
         private readonly Dictionary<string, string> _libraries = new Dictionary<string, string>();
         private readonly Dictionary<string, string> _nativeLibraries = new Dictionary<string, string>();
         private readonly string _packagesPath;
-        private static NuGetFramework _targetFramework = new NuGetFramework(".NETStandard,Version=v1.6");
 
         public EdgeAssemblyLoadContext(string bootstrapAssemblies)
         {

--- a/src/double/Edge.js/project.json
+++ b/src/double/Edge.js/project.json
@@ -11,10 +11,6 @@
     },
 
     "netstandard1.6": {
-      "imports": [
-        "portable-dnxcore50+net45+win8+wp8+wpa81"
-      ],
-
       "dependencies": {
         "NETStandard.Library": "1.6.0",
         "System.Console": "4.0.0",
@@ -31,7 +27,6 @@
         "System.Xml.ReaderWriter": "4.0.11",
         "System.Private.Uri": "4.0.1",
         "System.Collections.Specialized": "4.0.1",
-        "Microsoft.DotNet.ProjectModel": "1.0.0-rc3-003121",
         "Microsoft.Extensions.DependencyModel": "1.0.0",
         "Microsoft.DotNet.InternalAbstractions": "1.0.0",
         "System.AppContext": "4.1.0"


### PR DESCRIPTION
Removed unneeded dependency on Microsoft.DotNet.ProjectModel.  Not a huge priority, but something to bundle into the next release.