### PR TITLE
Fix #328 and improve #95, by passing the second parameter 'length', to

### DIFF
--- a/src/dotnet/utils.cpp
+++ b/src/dotnet/utils.cpp
@@ -7,7 +7,7 @@ v8::Local<v8::String> stringCLR2V8(System::String^ text)
     {
         array<unsigned char>^ utf8 = System::Text::Encoding::UTF8->GetBytes(text);
         pin_ptr<unsigned char> ch = &utf8[0];
-        return scope.Escape(Nan::New<v8::String>((char*)ch).ToLocalChecked());
+        return scope.Escape(Nan::New<v8::String>((char*)ch, utf8->Length).ToLocalChecked());
     }
     else
     {


### PR DESCRIPTION
`New<v8::String>`, which gives the buffer length.

If the data is UTF-8 encoded, the caller must be careful to supply the
length parameter. When it's not given, the function calls 'strlen' for
determining the buffer length, which might be wrong if 'data' contains
a null character.

See also:
https://v8docs.nodesource.com/node-0.10/d2/db3/classv8_1_1_string.html#a0d640550dbfa660872578ae7cb3c950b