### PR TITLE
Updated TravisCI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,19 @@ language: node_js
 node_js:
  - "0.12"
  - "0.10"
+ - "4.1.1"
+ - "5.1.0"
+ - "6.4.0"
 
 install:
  - sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
  - sudo sh -c "echo 'deb http://download.mono-project.com/repo/debian wheezy main' >> /etc/apt/sources.list.d/mono-xamarin.list"
  - sudo sh -c "echo 'deb http://download.mono-project.com/repo/debian wheezy-libtiff-compat main' >> /etc/apt/sources.list.d/mono-xamarin.list"
+ - sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
+ - sudo sh -c "echo 'deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main' > /etc/apt/sources.list.d/dotnetdev.list"
  - sudo apt-get update
- - sudo apt-get install mono-devel
+ - sudo apt-get install mono-devel dotnet-dev-1.0.0-preview2-003131
  - npm install -g grunt-cli
  - npm install
+ - npm test
+ - EDGE_USE_CORECLR=1 npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+dist: trusty
 
 node_js:
  - "0.12"
@@ -7,16 +8,19 @@ node_js:
  - "5.1.0"
  - "6.4.0"
 
-install:
+before_install:  
  - sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
  - sudo sh -c "echo 'deb http://download.mono-project.com/repo/debian wheezy main' >> /etc/apt/sources.list.d/mono-xamarin.list"
  - sudo sh -c "echo 'deb http://download.mono-project.com/repo/debian wheezy-libtiff-compat main' >> /etc/apt/sources.list.d/mono-xamarin.list"
  - sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
  - sudo sh -c "echo 'deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main' > /etc/apt/sources.list.d/dotnetdev.list"
  - sudo apt-get update
+
+install:
  - sudo apt-get install mono-devel dotnet-dev-1.0.0-preview2-003131
  - npm install -g grunt-cli
+
+script:
  - npm install
  - npm test
  - EDGE_USE_CORECLR=1 npm test
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,14 @@ node_js:
 
 before_install:  
  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
- - sudo sh -c "echo 'deb http://download.mono-project.com/repo/debian wheezy main' > /etc/apt/sources.list.d/mono-xamarin.list"
+ - sudo sh -c "echo 'deb http://download.mono-project.com/repo/debian wheezy/snapshots/4.2.4 main' > /etc/apt/sources.list.d/mono-xamarin.list"
  - sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
  - sudo sh -c "echo 'deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main' > /etc/apt/sources.list.d/dotnetdev.list"
  - sudo apt-get update
 
 install:
- - sudo apt-get install mono-devel dotnet-dev-1.0.0-preview2-003131
+ - sudo apt-get install mono-devel 
+ - sudo apt-get install dotnet-dev-1.0.0-preview2-003131
  - npm install -g grunt-cli
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,10 @@ install:
  - npm install -g grunt-cli
 
 script:
+ - dotnet build -c Release -f netstandard1.6 src/double/Edge.js
+ - cp src/double/Edge.js/bin/Release/netstandard1.6/EdgeJs.dll src/double/Edge.js/bin/Release/net40/EdgeJs.dll
+ - dotnet pack -c Release --no-build src/double/Edge.js
+ - dotnet restore lib/bootstrap -f src/double/Edge.js/bin/Release
  - npm install
  - npm test
- - EDGE_USE_CORECLR=1 npm test
+ - EDGE_USE_CORECLR=1 EDGE_DEBUG=1 npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,4 @@ install:
  - npm install
  - npm test
  - EDGE_USE_CORECLR=1 npm test
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
  - npm install -g grunt-cli
 
 script:
+ - dotnet restore src/double/Edge.js
  - dotnet build -c Release -f netstandard1.6 src/double/Edge.js
  - cp src/double/Edge.js/bin/Release/netstandard1.6/EdgeJs.dll src/double/Edge.js/bin/Release/net40/EdgeJs.dll
  - dotnet pack -c Release --no-build src/double/Edge.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,10 @@ install:
 script:
  - dotnet restore src/double/Edge.js
  - dotnet build -c Release -f netstandard1.6 src/double/Edge.js
+ - mkdir src/double/Edge.js/bin/Release/net40 
  - cp src/double/Edge.js/bin/Release/netstandard1.6/EdgeJs.dll src/double/Edge.js/bin/Release/net40/EdgeJs.dll
  - dotnet pack -c Release --no-build src/double/Edge.js
  - dotnet restore lib/bootstrap -f src/double/Edge.js/bin/Release
  - npm install
  - npm test
- - EDGE_USE_CORECLR=1 EDGE_DEBUG=1 npm test
+ - EDGE_USE_CORECLR=1 npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,8 @@ node_js:
  - "6.4.0"
 
 before_install:  
- - sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
- - sudo sh -c "echo 'deb http://download.mono-project.com/repo/debian wheezy main' >> /etc/apt/sources.list.d/mono-xamarin.list"
- - sudo sh -c "echo 'deb http://download.mono-project.com/repo/debian wheezy-libtiff-compat main' >> /etc/apt/sources.list.d/mono-xamarin.list"
+ - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+ - sudo sh -c "echo 'deb http://download.mono-project.com/repo/debian wheezy main' > /etc/apt/sources.list.d/mono-xamarin.list"
  - sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
  - sudo sh -c "echo 'deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main' > /etc/apt/sources.list.d/dotnetdev.list"
  - sudo apt-get update


### PR DESCRIPTION
Travis CI build definition now builds and tests Edge for both Mono and .NET Core across all of our supported Node.js versions.
