### PR TITLE
Attempt to fix compile error on Mac when pkg-config can not find the …

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -154,6 +154,9 @@
       }
     },
     {
+      'variables': {
+        'DFLT_PKG_CONFIG_PATH': 'PKG_CONFIG_PATH=/Library/Frameworks/Mono.framework/Versions/Current/lib/pkgconfig'
+      },
       'target_name': 'edge_nativeclr',
       'win_delay_load_hook': 'false',
       'include_dirs': [
@@ -203,14 +206,33 @@
                     'src/common/v8synchronizationcontext.cpp',
                     'src/common/edge.cpp'
                   ],
-                  'include_dirs': [
-                    '<!@(pkg-config mono-2 --cflags-only-I | sed s/-I//g)'
+                  'conditions': 
+                  [
+                    [
+                      '"<!((pkg-config mono-2 --libs 2>/dev/null) || echo not_found)"!="not_found"',
+                      {
+                            'include_dirs': [
+                              '<!@(pkg-config mono-2 --cflags-only-I | sed s/-I//g)'
+                            ],
+                            'link_settings': {
+                              'libraries': [
+                                '<!@(pkg-config mono-2 --libs)'
+                              ]
+                            }
+                      },
+                      '"<!((pkg-config mono-2 --libs 2>/dev/null) || echo not_found)"=="not_found"',
+                      {
+                            'include_dirs': [
+                              '<!@(<(DFLT_PKG_CONFIG_PATH) pkg-config mono-2 --cflags-only-I | sed s/-I//g)'
+                            ],
+                            'link_settings': {
+                              'libraries': [
+                                '<!@(<(DFLT_PKG_CONFIG_PATH) pkg-config mono-2 --libs)'
+                              ]
+                            }
+                      }
+                    ]
                   ],
-                  'link_settings': {
-                    'libraries': [
-                      '<!@(pkg-config mono-2 --libs)'
-                    ],
-                  }
                 },
                 {
                   'type': 'none'


### PR DESCRIPTION
…mono.pc file for mono-2.

For Mac the mono-2 package may not be found by pkg-config resulting in an error during install.

A way to resolve this is in my instance was to set the PKG_CONFIG_PATH according to the documentation which is for most cases /Library/Frameworks/Mono.framework/Versions/Current/lib/pkgconfig
# What the change does
- Create a variable call DFLT_PKG_CONFIG_PATH with the previous mentioned path allows for extension if need be in the future.
- Add two _conditions_ one which passes the normal pkg-config info if the mono package can be found and a second that will append the PKG_CONFIG_PATH to the command set with the variable described previously.
