### PR TITLE
Update Travis CI build with CoreCLR and NodeJS 4 & 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,22 @@
 language: node_js
+dist: trusty
+sudo: required
 
 node_js:
  - "0.12"
- - "0.10"
+ - "4.4"
+ - "6.1"
 
 install:
- - sudo apt-key adv --keyserver pgp.mit.edu --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+ - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+ - sudo sh -c "echo 'deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main' >> /etc/apt/sources.list.d/dotnetdev.list"
+ - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 417A0893
  - sudo sh -c "echo 'deb http://download.mono-project.com/repo/debian wheezy main' >> /etc/apt/sources.list.d/mono-xamarin.list"
- - sudo sh -c "echo 'deb http://download.mono-project.com/repo/debian wheezy-libtiff-compat main' >> /etc/apt/sources.list.d/mono-xamarin.list"
  - sudo apt-get update
  - sudo apt-get install mono-devel
- - npm install -g grunt-cli
+ - sudo apt-get install dotnet-dev-1.0.0-preview2-003131
+
+before_script :
  - npm install
+
+script: EDGE_USE_CORECLR=1 npm test


### PR DESCRIPTION
The build was actually failing since support for .NET Core was added.