### PR TITLE
Fix debug build with VS2015

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -247,7 +247,7 @@
           'msvs_settings': {
             'VCCLCompilerTool': {
               # this is out of range and will generate a warning and skip adding RuntimeLibrary property:
-              'RuntimeLibrary': -1,
+              'RuntimeLibrary': 3,
               # this is out of range and will generate a warning and skip adding RuntimeTypeInfo property:
               'RuntimeTypeInfo': -1,
               'BasicRuntimeChecks': -1,


### PR DESCRIPTION
The debug build on Windows for Native CLR was throwing linker errors
because the wrong MSVCRT was being linked in.

The fix is to use the runtime multi-threaded *debug* DLL, and the best
solution to getting node-gyp to use it is to set the RuntimeLibrary
property to '3'.

Docs on RuntimeLibrary property:
https://msdn.microsoft.com/en-us/library/aa652367%28v=vs.71%29.aspx

Fix for #454 