### PR TITLE
Fix build error with glibc 2.26 xlocale.h

### DIFF
--- a/src/CoreCLREmbedding/cpprest/include/asyncrt_utils.h
+++ b/src/CoreCLREmbedding/cpprest/include/asyncrt_utils.h
@@ -40,7 +40,9 @@
 
 #ifndef _WIN32
 //#include <boost/algorithm/string.hpp>
-#if !defined(ANDROID) && !defined(__ANDROID__) // CodePlex 269
+#if !defined(ANDROID) && !defined(__ANDROID__) && !defined(__GLIBC__)// CodePlex 269
+/* Systems using glibc: xlocale.h has been removed from glibc 2.26
+   Include of locale.h is sufficient*/
 #include <xlocale.h>
 #endif
 #endif

--- a/src/CoreCLREmbedding/json/casablanca/include/cpprest/asyncrt_utils.h
+++ b/src/CoreCLREmbedding/json/casablanca/include/cpprest/asyncrt_utils.h
@@ -40,7 +40,9 @@
 
 #ifndef _WIN32
 //#include <boost/algorithm/string.hpp>
-#if !defined(ANDROID) && !defined(__ANDROID__) // CodePlex 269
+#if !defined(ANDROID) && !defined(__ANDROID__) && !defined(__GLIBC__)// CodePlex 269
+/* Systems using glibc: xlocale.h has been removed from glibc 2.26
+   Include of locale.h is sufficient*/
 #include <xlocale.h>
 #endif
 #endif


### PR DESCRIPTION
- Do not include xlocale.h on systems, where GLIBC is defined
xlocale.h has been removed from glibc 2.26
The include of locale.h in asyncrt_utils.h is sufficient
Further details:
https://sourceware.org/git/?p=glibc.git;a=commit;h=f0be25b
- Fixes #644